### PR TITLE
Use kerberos-sspi on win32

### DIFF
--- a/django_auth_kerberos/backends.py
+++ b/django_auth_kerberos/backends.py
@@ -1,4 +1,7 @@
-import kerberos
+try:
+    import kerberos
+except ImportError:
+    import kerberos_sspi as kerberos
 import logging
 
 from django.conf import settings

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
+import sys
+
+if sys.platform.startswith("win"):
+    pykerberos = 'kerberos-sspi>=0.2'
+else:
+    pykerberos = 'pykerberos>=1.1.3'
+
 
 setup(
     name="django-auth-kerberos",
@@ -26,6 +33,6 @@ setup(
     packages=find_packages(exclude='tests'),
     install_requires=[
         'Django>=1.6',
-        'pykerberos>=1.1.3',
+        pykerberos,
     ],
 )


### PR DESCRIPTION
For better win32 support, make use of kerberos-sspi (using pywin32) on win32.